### PR TITLE
Add qt5.qtgraphicaleffects to mirage build

### DIFF
--- a/pkgs/mirage/default.nix
+++ b/pkgs/mirage/default.nix
@@ -24,6 +24,7 @@ mkDerivation rec {
     olm
     openjpeg
     pyotherside
+    qt5.qtgraphicaleffects
     qt5.qtimageformats
     qt5.qtquickcontrols2
     qt5.qtsvg


### PR DESCRIPTION
This was required for mirage to start for me.

Also for some reason this package fails when using nix-shell with
```
bash: role_pre: unbound variable
```

Not sure why.